### PR TITLE
Delete OverlayFS warning in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Enjoy!
 
 - SuSfs is enabled for production builds
 
-- Stock rom users might face some problems with Overlayfs
-
 
 
 # Compilation:


### PR DESCRIPTION
Deleted the line which states "Stock rom users might face some problems with Overlayfs", as this issue had been resolved in newer versions